### PR TITLE
feat(device_view): adapt the view to list all dashboards and layouts

### DIFF
--- a/cos_registration_server/devices/templates/devices/device.html
+++ b/cos_registration_server/devices/templates/devices/device.html
@@ -1,6 +1,10 @@
 <p>Device {{device.uid}} with ip {{device.address}}, was created on the {{device.creation_date}}</p>
 <ul>
-{% for name, link in links_dict.items %}
-    <li><a href="{{request.scheme}}://{{link}}">{{ name }}</a></li>
+{% for application_link in links_list%}
+    <li><a href="{{request.scheme}}://{{application_link.main_link}}">{{ application_link.name }}</a>
+        {% for name, link in application_link.additional_links.items %}
+            <ul><a href="{{request.scheme}}://{{link}}">{{ name }}</a></ul>
+        {% endfor %}
+    </li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
Extend the device view so we have links to all the associated dashboards and applications

![image](https://github.com/ubuntu-robotics/cos-registration-server/assets/8058486/2c9a42f6-d5a6-4c19-a66e-ca3881866dbb)
