### PR TITLE
Dev/device get filtered attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ requiring to access the device database.
 
 #### Devices
 <details>
- <summary><code>GET</code> <code><b>api/v1/devices</b></code> <code>(Get the list of all the devices)</code></summary>
+ <summary><code>GET</code> <code><b>api/v1/devices/</b></code> <code>(Get the list of all the devices)</code></summary>
 
 ##### Parameters
 
@@ -85,7 +85,7 @@ requiring to access the device database.
 </details>
 
 <details>
- <summary><code>POST</code> <code><b>api/v1/devices</b></code> <code>(Add a device to the database)</code></summary>
+ <summary><code>POST</code> <code><b>api/v1/devices/</b></code> <code>(Add a device to the database)</code></summary>
 
 ##### Parameters
 
@@ -104,7 +104,7 @@ requiring to access the device database.
 </details>
 
 <details>
- <summary><code>GET</code> <code><b>api/v1/device/&#60str:uid&#62;</b></code> <code>(Get the details of a device)</code></summary>
+ <summary><code>GET</code> <code><b>api/v1/device/&#60str:uid&#62;/</b></code> <code>(Get the details of a device)</code></summary>
 
 ##### Parameters
 
@@ -119,7 +119,7 @@ requiring to access the device database.
 </details>
 
 <details>
- <summary><code>PATCH</code> <code><b>api/v1/device/&#60str:uid&#62;</b></code> <code>(Modify the attribute of a device)</code></summary>
+ <summary><code>PATCH</code> <code><b>api/v1/device/&#60str:uid&#62;/</b></code> <code>(Modify the attribute of a device)</code></summary>
 
 ##### Parameters
 
@@ -138,7 +138,7 @@ requiring to access the device database.
 </details>
 
 <details>
- <summary><code>DELETE</code> <code><b>api/v1/device/&#60str:uid&#62;</b></code> <code>(Delete a device from the database)</code></summary>
+ <summary><code>DELETE</code> <code><b>api/v1/device/&#60str:uid&#62;/</b></code> <code>(Delete a device from the database)</code></summary>
 
 ##### Parameters
 
@@ -155,7 +155,7 @@ requiring to access the device database.
 #### Applications
 
 <details>
- <summary><code>GET</code> <code><b>api/v1/applications/grafana/dashboards</b></code> <code>(Get the details of a Grafana dashboards)</code></summary>
+ <summary><code>GET</code> <code><b>api/v1/applications/grafana/dashboards/</b></code> <code>(Get the details of a Grafana dashboards)</code></summary>
 
 ##### Parameters
 
@@ -170,7 +170,7 @@ requiring to access the device database.
 </details>
 
 <details>
- <summary><code>POST</code> <code><b>api/v1/applications/grafana/dashboards</b></code> <code>(Add a Grafana dashboard to the database)</code></summary>
+ <summary><code>POST</code> <code><b>api/v1/applications/grafana/dashboards/</b></code> <code>(Add a Grafana dashboard to the database)</code></summary>
 
 ##### Parameters
 
@@ -189,7 +189,7 @@ requiring to access the device database.
 </details>
 
 <details>
- <summary><code>GET</code> <code><b>api/v1/applications/grafana/dashboards/&#60str:uid&#62;</b></code> <code>(Get the details of a Grafana dashboard)</code></summary>
+ <summary><code>GET</code> <code><b>api/v1/applications/grafana/dashboards/&#60str:uid&#62;/</b></code> <code>(Get the details of a Grafana dashboard)</code></summary>
 
 ##### Parameters
 
@@ -204,7 +204,7 @@ requiring to access the device database.
 </details>
 
 <details>
- <summary><code>PATCH</code> <code><b>api/v1/applications/grafana/dashboards/&#60str:uid&#62;</b></code> <code>(Modify the attribute of a GrafanaDashboard)</code></summary>
+ <summary><code>PATCH</code> <code><b>api/v1/applications/grafana/dashboards/&#60str:uid&#62;/</b></code> <code>(Modify the attribute of a GrafanaDashboard)</code></summary>
 
 ##### Parameters
 
@@ -223,7 +223,7 @@ requiring to access the device database.
 </details>
 
 <details>
- <summary><code>DELETE</code> <code><b>api/v1/applications/grafana/dashboards/&#60str:uid&#62;</b></code> <code>(Delete a Grafana dashboard from the database)</code></summary>
+ <summary><code>DELETE</code> <code><b>api/v1/applications/grafana/dashboards/&#60str:uid&#62;/</b></code> <code>(Delete a Grafana dashboard from the database)</code></summary>
 
 ##### Parameters
 
@@ -238,7 +238,7 @@ requiring to access the device database.
 </details>
 
 <details>
- <summary><code>GET</code> <code><b>api/v1/applications/foxglove/dashboards</b></code> <code>(Get the details of a Foxglove dashboards)</code></summary>
+ <summary><code>GET</code> <code><b>api/v1/applications/foxglove/dashboards/</b></code> <code>(Get the details of a Foxglove dashboards)</code></summary>
 
 ##### Parameters
 
@@ -253,7 +253,7 @@ requiring to access the device database.
 </details>
 
 <details>
- <summary><code>POST</code> <code><b>api/v1/applications/foxglove/dashboards</b></code> <code>(Add a Foxglove dashboard to the database)</code></summary>
+ <summary><code>POST</code> <code><b>api/v1/applications/foxglove/dashboards/</b></code> <code>(Add a Foxglove dashboard to the database)</code></summary>
 
 ##### Parameters
 
@@ -272,7 +272,7 @@ requiring to access the device database.
 </details>
 
 <details>
- <summary><code>GET</code> <code><b>api/v1/applications/foxglove/dashboards/&#60str:uid&#62;</b></code> <code>(Get the details of a Foxglove dashboard)</code></summary>
+ <summary><code>GET</code> <code><b>api/v1/applications/foxglove/dashboards/&#60str:uid&#62;/</b></code> <code>(Get the details of a Foxglove dashboard)</code></summary>
 
 ##### Parameters
 
@@ -287,7 +287,7 @@ requiring to access the device database.
 </details>
 
 <details>
- <summary><code>PATCH</code> <code><b>api/v1/applications/foxglove/dashboards/&#60str:uid&#62;</b></code> <code>(Modify the attribute of a FoxgloveDashboard)</code></summary>
+ <summary><code>PATCH</code> <code><b>api/v1/applications/foxglove/dashboards/&#60str:uid&#62;/</b></code> <code>(Modify the attribute of a FoxgloveDashboard)</code></summary>
 
 ##### Parameters
 
@@ -306,7 +306,7 @@ requiring to access the device database.
 </details>
 
 <details>
- <summary><code>DELETE</code> <code><b>api/v1/applications/foxglove/dashboards/&#60str:uid&#62;</b></code> <code>(Delete a Foxglove dashboard from the database)</code></summary>
+ <summary><code>DELETE</code> <code><b>api/v1/applications/foxglove/dashboards/&#60str:uid&#62;/</b></code> <code>(Delete a Foxglove dashboard from the database)</code></summary>
 
 ##### Parameters
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ requiring to access the device database.
 
 ##### Parameters
 
-> None
+> fields: comma seperated fields selection to get. Default to all.
 
 ##### Responses
 
@@ -108,13 +108,13 @@ requiring to access the device database.
 
 ##### Parameters
 
-> None
+> fields: comma seperated fields selection to get. Default to all.
 
 ##### Responses
 
 > | http code     | content-type                      | response                                                            |
 > |---------------|-----------------------------------|---------------------------------------------------------------------|
-> | `200`         | `application/json`        | {"uid": "string", "creation_date": "string", "address": "string", "grafana_dashboards": "list(grafana_dashboards_uid" , "foxglove_dashboards": "list(foxglove_dashboards_uid)}                                                         |
+> | `200`         | `application/json`        | {"uid": "string", "creation_date": "string", "address": "string", "grafana_dashboards": "list(grafana_dashboards_uid)" , "foxglove_dashboards": "list(foxglove_dashboards_uid)}                                                         |
 > | `404`         | `text/html;charset=utf-8`        | None                                                         |
 </details>
 

--- a/cos_registration_server/api/serializer.py
+++ b/cos_registration_server/api/serializer.py
@@ -122,6 +122,29 @@ class DeviceSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
             "foxglove_dashboards",
         )
 
+    def to_representation(self, instance: Device) -> Dict[str, Any]:
+        """Repesent filter by fields serialized data.
+
+        Overrides the default behavior to return a
+        dictionary containing only the fields
+        specified in the URL parameter 'fields' (comma-separated list).
+        If no 'fields' parameter is provided,
+        returns the entire serialized data.
+
+        instance: The Device model instance to be serialized.
+
+        Returns a dictionary containing the requested or
+        all fields of the serialized data.
+        """
+        data = super().to_representation(instance)
+        if request := self.context.get("request"):
+            if requested_fields := request.query_params.get("fields"):
+                return {
+                    field: data[field] for field in requested_fields.split(",")
+                }
+
+        return data
+
     def create(self, validated_data: Dict[str, Any]) -> Device:
         """Create Device object from data.
 

--- a/cos_registration_server/api/tests.py
+++ b/cos_registration_server/api/tests.py
@@ -122,6 +122,26 @@ class DevicesViewTests(APITestCase):
             self.assertEqual(device.get("grafana_dashboards"), [])
             self.assertEqual(device.get("foxglove_dashboards"), [])
 
+    def test_get_devices_with_filtered_fields(self) -> None:
+        devices = [
+            {"uid": "robot-1", "address": "192.168.0.1"},
+            {"uid": "robot-2", "address": "192.168.0.2"},
+            {"uid": "robot-3", "address": "192.168.0.3"},
+        ]
+        for device in devices:
+            self.create_device(uid=device["uid"], address=device["address"])
+        self.assertEqual(Device.objects.count(), 3)
+
+        params = {"fields": "creation_date,address"}
+        response = self.client.get(self.url, data=params)
+        self.assertEqual(response.status_code, 200)
+        content_json = json.loads(response.content)
+        self.assertEqual(len(content_json), 3)
+        for i, device in enumerate(content_json):
+            self.assertIsNone(device.get("uid"))
+            self.assertEqual(devices[i]["address"], device["address"])
+            self.assertIsNotNone(device.get("creation_date"))
+
     def test_create_already_present_uid(self) -> None:
         uid = "robot-1"
         address = "192.168.0.1"

--- a/cos_registration_server/api/tests.py
+++ b/cos_registration_server/api/tests.py
@@ -118,6 +118,9 @@ class DevicesViewTests(APITestCase):
         for i, device in enumerate(content_json):
             self.assertEqual(devices[i]["uid"], device["uid"])
             self.assertEqual(devices[i]["address"], device["address"])
+            self.assertIsNotNone(device.get("creation_date"))
+            self.assertEqual(device.get("grafana_dashboards"), [])
+            self.assertEqual(device.get("foxglove_dashboards"), [])
 
     def test_create_already_present_uid(self) -> None:
         uid = "robot-1"
@@ -130,7 +133,7 @@ class DevicesViewTests(APITestCase):
         self.assertEqual(Device.objects.count(), 1)
         self.assertContains(
             response,
-            '{"uid": ["device with this uid already exists."]}',
+            '{"uid":["device with this uid already exists."]}',
             status_code=400,
         )
 
@@ -145,7 +148,7 @@ class DevicesViewTests(APITestCase):
         self.assertEqual(Device.objects.count(), 0)
         self.assertContains(
             response,
-            '{"grafana_dashboards": ["Object with uid=dashboard-1 does not exist."]}',
+            '{"grafana_dashboards":["Object with uid=dashboard-1 does not exist."]}',
             status_code=400,
         )
 
@@ -155,7 +158,7 @@ class DevicesViewTests(APITestCase):
         self.assertEqual(Device.objects.count(), 0)
         self.assertContains(
             response,
-            '{"foxglove_dashboards": ["Object with uid=dashboard-1 does not exist."]}',
+            '{"foxglove_dashboards":["Object with uid=dashboard-1 does not exist."]}',
             status_code=400,
         )
 
@@ -171,7 +174,7 @@ class DevicesViewTests(APITestCase):
         self.assertEqual(Device.objects.count(), 0)
         self.assertContains(
             response,
-            '{"grafana_dashboards": ["Expected a list of items but got type \\"str\\".',
+            '{"grafana_dashboards":["Expected a list of items but got type \\"str\\".',
             status_code=400,
         )
 
@@ -183,7 +186,7 @@ class DevicesViewTests(APITestCase):
         self.assertEqual(Device.objects.count(), 0)
         self.assertContains(
             response,
-            '{"foxglove_dashboards": ["Expected a list of items but got type \\"str\\".',
+            '{"foxglove_dashboards":["Expected a list of items but got type \\"str\\".',
             status_code=400,
         )
 
@@ -439,7 +442,7 @@ class GrafanaDashboardsViewTests(APITestCase):
         self.assertEqual(GrafanaDashboard.objects.count(), 1)
         self.assertContains(
             response,
-            '{"uid": ["grafana dashboard with this uid already exists."]}',
+            '{"uid":["grafana dashboard with this uid already exists."]}',
             status_code=400,
         )
 
@@ -452,7 +455,7 @@ class GrafanaDashboardsViewTests(APITestCase):
         self.assertEqual(GrafanaDashboard.objects.count(), 0)
         self.assertContains(
             response,
-            '{"dashboard": ["Failed to load dashboard as json."]}',
+            '{"dashboard":["Failed to load dashboard as json."]}',
             status_code=400,
         )
 

--- a/cos_registration_server/api/urls.py
+++ b/cos_registration_server/api/urls.py
@@ -8,26 +8,26 @@ app_name = "api"
 
 urlpatterns = [
     # make a version API url
-    path("v1/devices", views.devices, name="devices"),
-    path("v1/devices/<str:uid>", views.device, name="device"),
+    path("v1/devices/", views.DevicesView.as_view(), name="devices"),
+    path("v1/devices/<str:uid>/", views.DeviceView.as_view(), name="device"),
     path(
-        "v1/applications/grafana/dashboards",
-        views.grafana_dashboards,
+        "v1/applications/grafana/dashboards/",
+        views.GrafanaDashboardsView.as_view(),
         name="grafana_dashboards",
     ),
     path(
-        "v1/applications/grafana/dashboards/<str:uid>",
-        views.grafana_dashboard,
+        "v1/applications/grafana/dashboards/<str:uid>/",
+        views.GrafanaDashboardView.as_view(),
         name="grafana_dashboard",
     ),
     path(
-        "v1/applications/foxglove/dashboards",
-        views.foxglove_dashboards,
+        "v1/applications/foxglove/dashboards/",
+        views.FoxgloveDashboardsView.as_view(),
         name="foxglove_dashboards",
     ),
     path(
-        "v1/applications/foxglove/dashboards/<str:uid>",
-        views.foxglove_dashboard,
+        "v1/applications/foxglove/dashboards/<str:uid>/",
+        views.FoxgloveDashboardView.as_view(),
         name="foxglove_dashboard",
     ),
 ]

--- a/cos_registration_server/cos_registration_server/settings.py
+++ b/cos_registration_server/cos_registration_server/settings.py
@@ -48,6 +48,14 @@ INSTALLED_APPS = [
     "rest_framework",
 ]
 
+REST_FRAMEWORK = {
+    "DEFAULT_PARSER_CLASSES": [
+        "rest_framework.parsers.JSONParser",
+        "rest_framework.parsers.FormParser",
+    ]
+}
+
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
- refactor of the views to leverage all the possibilities of Django rest framework API views.
- Add `to_representation` method that can filter based on "fields" url parameter.

We can now hit: `http://127.0.0.1:8000/api/v1/devices/?fields=uid,creation_date`