### PR TITLE
fix(rock): remove call top delete command update_all_dashboards

### DIFF
--- a/rock/local/configure.bash
+++ b/rock/local/configure.bash
@@ -7,5 +7,3 @@ export SECRET_KEY_DJANGO=$(cat /server_data/secret_key)
 # migrate the database
 /bin/python3 manage.py migrate
 
-# update all the dashboards
-python3 manage.py update_all_dashboards


### PR DESCRIPTION
This command was deleted long back.

Somhow this wasn't causing any issues before.
It could be that a recent change in rock or charms is no making this causing an issue.

Essentially, the `configure.bash` script fails due to the command not existing.

This make the ingress relation fail.
