### PR TITLE
ci(rock-release): add proper permissions

### DIFF
--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -15,6 +15,9 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
 
     - name: Checkout repository


### PR DESCRIPTION
Something must have changed at the GH level or at the Canonical org level.

We now require explicit permissions to publish on the registry.